### PR TITLE
Enable and fix ruff `C90`, `SIM`, and `YTT` lints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ select = [
     "F",
     # pycodestyle
     "E",
+    # mccabe
+    "C90",
     # isort
     "I",
     # pep8-naming
@@ -118,6 +120,8 @@ select = [
     "D",
     # pyupgrade
     "UP",
+    # flake8-2020
+    "YTT",
     # flake8-bugbear
     "B",
     # flake8-builtins
@@ -134,6 +138,8 @@ select = [
     "Q",
     # flake8-debugger
     "T10",
+    # flake8-simplify
+    "SIM",
     # PyLint
     "PLE", "PLW",
     # ruff-specific
@@ -153,6 +159,8 @@ extend-ignore = [
     "C419",
     # Allow pytest.raises() without match
     "PT011",
+    # Allow try-except-pass and nested with statements
+    "SIM105", "SIM117",
 ]
 line-length = 79
 target-version = "py38"

--- a/testing/connectors.py
+++ b/testing/connectors.py
@@ -112,11 +112,8 @@ def zmq_connector() -> Generator[Connector[Any], None, None]:
     """ZeroMQ store fixture."""
     port = open_port()
 
-    if platform.system() == 'Darwin':  # pragma: no cover
-        # MacOS GitHub Actions runners are slow
-        timeout = 1.0
-    else:  # pragma: no cover
-        timeout = 0.5
+    # MacOS GitHub Actions runners are slow
+    timeout = 1.0 if platform.system() == 'Darwin' else 0.5
 
     with zmq.ZeroMQConnector(
         port=port,

--- a/tests/connectors/dim/zmq_test.py
+++ b/tests/connectors/dim/zmq_test.py
@@ -16,11 +16,8 @@ from proxystore_ex.connectors.dim.zmq import ZeroMQServer
 from testing.compat import randbytes
 from testing.utils import open_port
 
-if platform.system() == 'Darwin':  # pragma: no cover
-    # MacOS GitHub Actions runners are slow
-    TIMEOUT = 1.0
-else:  # pragma: no cover
-    TIMEOUT = 0.5
+# MacOS GitHub Actions runners are slow
+TIMEOUT = 1.0 if platform.system() == 'Darwin' else 0.5
 
 TEST_KEY = DIMKey(
     'zmq',


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Enable and fix ruff `C90`, `SIM`, and `YTT`  lints (mccabe, flake8-simplify, and flake8-2020).

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [x] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Ruff passes.

## Pull Request Checklist

- [x] I have read the [Contributing](https://extensions.proxystore.dev/main/contributing/) and [PR submission](https://extensions.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
