### PR TITLE
Alias docs for latest release as stable and make the default

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,4 +59,4 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           pip install .[docs]
-          mike deploy --push "${{ env.PACKAGE_VERSION }}"
+          mike deploy --push --update-aliases "${{ env.PACKAGE_VERSION }}" stable


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

I've updated the gh-pages branch via mike to default to the stable alias which will now point at the latest release. The main (and latest alias) still exists, just aren't the default when you go to [extensions.proxystore.dev](https://extensions.proxystore.dev/).

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [x] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [x] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

- [x] I have read the [Contributing](https://extensions.proxystore.dev/main/contributing/) and [PR submission](https://extensions.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
