### PR TITLE
Fix proxy argument parsing error in Dask 2024.11.1 and later

### DIFF
--- a/testing/connectors.py
+++ b/testing/connectors.py
@@ -10,12 +10,7 @@ from typing import Generator
 from unittest import mock
 
 import pytest
-
-try:
-    from proxystore.connectors.connector import Connector
-except ImportError:  # pragma: no cover
-    # This import changed in ProxyStore v0.6.1
-    from proxystore.connectors.protocols import Connector
+from proxystore.connectors.protocols import Connector
 
 from proxystore_ex.connectors.daos import DAOSConnector
 from proxystore_ex.connectors.dim import margo


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Dask Distributed 2024.11.1 changed how tasks are represented and subsequently introduces parsing logic that was not compatible with proxy types where the target object was a builtin collection type. This PR fixes that problem while maintaining backwards compatibility. I have also make private some of the proxy parsing methods.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [ ] Enhancement (new features or improvements to existing functionality)
- [x] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Tests pass again after failing CI.

## Pull Request Checklist

- [x] I have read the [Contributing](https://extensions.proxystore.dev/main/contributing/) and [PR submission](https://extensions.proxystore.dev/main/contributing/issues-pull-requests/) guides.

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
